### PR TITLE
Fix example application crash on Linux

### DIFF
--- a/example/imageSender/CMakeLists.txt
+++ b/example/imageSender/CMakeLists.txt
@@ -6,12 +6,10 @@ enable_testing()
 
 set(cmake_exe_com)
 
-if (WIN32)
-    set(Boost_USE_STATIC_LIBS ON)
-else()
-    set(GCC_COVERAGE_COMPILE_FLAGS  "-fPIC")
-    set(CMAKE_CXX_FLAGS             "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")
-    set(GCC_COVERAGE_LINK_FLAGS     "-shared")
+set(Boost_USE_STATIC_LIBS ON)
+
+if (NOT WIN32)
+    set(GCC_COVERAGE_LINK_FLAGS     "-Wl,--allow-shlib-undefined")
     set(CMAKE_EXE_LINKER_FLAGS      "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")
 endif()
 

--- a/example/imageSender/source/ImageSenderDllSession.h
+++ b/example/imageSender/source/ImageSenderDllSession.h
@@ -7,7 +7,8 @@
     {                                                \
         auto capturedCode = (code);                  \
         if(capturedCode != 0) {                      \
-            std::cerr << capturedCode << std::endl;  \
+            /* TODO: refine error description */     \
+            throw std::runtime_error("Image sender error with code: " + std::to_string(code));  \
         }                                            \
     } \
 

--- a/example/imageSender/source/main.cpp
+++ b/example/imageSender/source/main.cpp
@@ -116,6 +116,9 @@ int main(int argc, char** argv) {
         }
 
         session.Close();
+        
+        std::cout << std::endl << std::endl;
+        std::cout << "Total Frames: " << totalFramesProcessed << std::endl;
     }
     catch (std::exception& e) {
         std::cerr << e.what() << std::endl;

--- a/example/imageSender/source/main.cpp
+++ b/example/imageSender/source/main.cpp
@@ -27,8 +27,8 @@ int main(int argc, char** argv) {
             ("help",     "produce help message")
             ("width", boost::program_options::value<int>(&inputProps.width), "Specify the width of the image")
             ("height", boost::program_options::value<int>(&inputProps.height), "Specify the height of the image")
-            ("localAddress", boost::program_options::value<std::string>(&localAddress), "Specify the local RDMA IP address to listen on")
-            ("localPort", boost::program_options::value<uint16_t>(&localPort), "Specify the local RDMA port number to listen on")
+            ("localAddress", boost::program_options::value<std::string>(&localAddress)->required(), "Specify the local RDMA IP address to listen on")
+            ("localPort", boost::program_options::value<uint16_t>(&localPort)->required(), "Specify the local RDMA port number to listen on")
             ("backChannelPort", boost::program_options::value<uint16_t>(&backChannelPort), "Specify the local RDMA port number to listen on for backchannel commands")
             ("rdmaChunkSize", boost::program_options::value<int>(&rdmaChunkSize), "RDMA sender chunk size (default 1MB)")
             ("preEmbeddedDataLineCount", boost::program_options::value<int>(&preEmbeddedDataLineCount), "Pre-embedded data line count")
@@ -77,7 +77,7 @@ int main(int argc, char** argv) {
 
         session.Create(inputProps, outputProps, rdmaProps);
         std::cout << "Waiting for RDMA connection ..." << std::endl;
-        session.AcceptConnection(30000);
+        session.AcceptConnection(-1);
         
         // Construct embedded data
         std::vector<EmbeddedDataLineInternal> preEmbeddedDataLines(outputProps.preEmbeddedDataLineCount);


### PR DESCRIPTION
Fix issue #2 
Customer reported our example application crashed on Linux platform, this PR fix the issue as per @ericgross2's suggestion by changing the Linker flag from "-shared" to "--allow-shlib-undefined"
